### PR TITLE
Split tile calculations and carving into two separate nodes

### DIFF
--- a/images_to_grids.py
+++ b/images_to_grids.py
@@ -848,7 +848,6 @@ class ImageToXYImageTilesOutput(BaseInvocationOutput):
     xyImages: list[str] = OutputField(description="The XYImage Collection")
     tile_x: int = OutputField(description="The tile x dimension")
     tile_y: int = OutputField(description="The tile y dimension")
-    overlap: int = OutputField(description="The tile overlap size")
 
 
 @invocation(
@@ -894,7 +893,6 @@ class ImageToXYImageTilesInvocation(BaseInvocation, WithWorkflow):
             xyImages=xyimages,
             tile_x=tile_x,
             tile_y=tile_y,
-            overlap=overlap,
         )
 
 

--- a/images_to_grids.py
+++ b/images_to_grids.py
@@ -823,8 +823,16 @@ class MinimumOverlapXYTileGenerator(BaseInvocation, WithWorkflow):
         if img.height < self.tile_height:
             self.tile_height = img.height
 
-        num_tiles_w = math.ceil(img.width / (self.tile_width - self.min_overlap)) if self.tile_width < img.width else 1
-        num_tiles_h = math.ceil(img.height / (self.tile_height - self.min_overlap)) if self.tile_height < img.height else 1
+        num_tiles_w = (
+            math.ceil((img.width - self.min_overlap) / (self.tile_width - self.min_overlap))
+            if self.tile_width < img.width
+            else 1
+        )
+        num_tiles_h = (
+            math.ceil((img.height - self.min_overlap) / (self.tile_height - self.min_overlap))
+            if self.tile_height < img.height
+            else 1
+        )
 
         xytiles = []
 
@@ -1090,4 +1098,3 @@ class CropLatentsInvocation(BaseInvocation):
         context.services.latents.save(name, cropped_latents)
 
         return build_latents_output(latents_name=name, latents=cropped_latents)
-


### PR DESCRIPTION
This PR splits up the ImageToXYImageTilesInvocation and requires it to use the output of a tile generator. Two generators are included - the default one and one that lets the user specify a minimum overlap and tile size.

ImageToXYImageTilesInvocation also no longer outputs the overlap since that makes little sense where generators can make their own decisions about overlap size.